### PR TITLE
Go to definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description": "VSCode CIMPL Language Support",
 	"author": "The MITRE Corporation",
 	"license": "Apache-2.0",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"publisher": "Standard Health Record",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,12 @@
 				"path": "./syntaxes/cimpl.tmLanguage.json"
 			}
 		],
-		"commands": []
+		"commands": [
+			{
+				"command": "extension.parseFolders",
+				"title": "Parse Folders"
+			}
+		]
 	},
 	"scripts": {
 		"vscode:prepublish": "tsc -p ./",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
 		],
 		"commands": [
 			{
-				"command": "extension.parseFolders",
-				"title": "Parse Folders"
+				"command": "extension.goToDefinition",
+				"title": "Go to Definition"
 			}
 		]
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,29 +8,17 @@ import {
 	commands, window, workspace, Selection, TextEditorEdit, ExtensionContext
 } from 'vscode';
 
-// import { importFromFilePath } from './parser';
+import { importFromFilePath } from './parser';
 
 export function activate(context: ExtensionContext) {
 
-	// context.subscriptions.push(commands.registerCommand('extension.parseFolders', () => {
-	// 	let parsedFiles: any = {};
-	// 	const regexp = /file:\/\/(.+)/;
-	// 	workspace.workspaceFolders.forEach((folder) => {
-	// 		console.log(folder);
-	// 		const folderPath = regexp.exec(folder.uri.toString())[1];
-	// 		const parsedFolder = importFromFilePath(folderPath);
-	// 		parsedFiles = Object.assign(parsedFolder, parsedFiles);
-	// 		console.log(parsedFiles);
-	// 	});
-	// }));
-
-	// Example command for text editing, kept for reference
-	// context.subscriptions.push(commands.registerCommand('extension.sayHello', () => {
-	// 	const editor = window.activeTextEditor;
-	// 	const position = editor.selection.active;
-
-    //     editor.edit((editBuilder : TextEditorEdit) => {
-	// 		editBuilder.insert(position, "Hello");
-	// 	});
-	// }));
+	context.subscriptions.push(commands.registerCommand('extension.parseFolders', () => {
+		let parsedFiles: any = {};
+		const regexp = /file:\/\/(.+)/;
+		workspace.workspaceFolders.forEach((folder) => {
+			const folderPath = regexp.exec(folder.uri.toString())[1];
+			const parsedFolder = importFromFilePath(folderPath);
+			parsedFiles = Object.assign(parsedFolder, parsedFiles);
+		});
+	}));
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import {
-	commands, window, workspace, Selection, TextEditorEdit, ExtensionContext
+	commands, window, workspace, Selection, Position, TextEditor, TextEditorEdit, TextLine, ExtensionContext
 } from 'vscode';
 
 import { importFromFilePath } from './parser';
@@ -15,10 +15,46 @@ export function activate(context: ExtensionContext) {
 	context.subscriptions.push(commands.registerCommand('extension.parseFolders', () => {
 		let parsedFiles: any = {};
 		const regexp = /file:\/\/(.+)/;
+		
+		const editor: TextEditor = window.activeTextEditor;
+		const selection: Selection = editor.selection;
+		const position: Position = selection.active;
+		let elementName: string;
+		let selectedText: string;
+
+		for (let i: number = position.line; i >= 0; i--) {
+			const currentLine: TextLine = editor.document.lineAt(i);
+			if (currentLine.text.includes("Element:") && !currentLine.text.includes("//")) {
+				const currentLineArray: string[] = currentLine.text.replace(/\t/g, " ").split(" ");
+				elementName = currentLineArray[currentLineArray.length - 1];
+				break;
+			}
+		}
+
+		if (!selection.isEmpty) {
+			selectedText = editor.document.getText(selection);
+			window.showInformationMessage(`Selected Text: ${selectedText}`);
+		} else {
+			window.showErrorMessage("No text selected.");
+		}
+
+		if (elementName) {
+			window.showInformationMessage(`Current Element: ${elementName}`);
+		} else {
+			window.showErrorMessage("Not editing Element.");
+		}
+
 		workspace.workspaceFolders.forEach((folder) => {
 			const folderPath = regexp.exec(folder.uri.toString())[1];
 			const parsedFolder = importFromFilePath(folderPath);
 			parsedFiles = Object.assign(parsedFolder, parsedFiles);
 		});
+
+		const parsedActiveFile = parsedFiles[editor.document.fileName];
+		if (parsedActiveFile) {
+			window.showInformationMessage(`File ${editor.document.fileName} parsed.`);
+		} else {
+			window.showErrorMessage(`Could not parse file ${editor.document.fileName}.`)
+		}
 	}));
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,8 +25,13 @@ export function activate(context: ExtensionContext) {
 		for (let i: number = position.line; i >= 0; i--) {
 			const currentLine: TextLine = editor.document.lineAt(i);
 			if (currentLine.text.includes("Element:") && !currentLine.text.includes("//")) {
-				const currentLineArray: string[] = currentLine.text.replace(/\t/g, " ").split(" ");
-				elementName = currentLineArray[currentLineArray.length - 1];
+				let currentLineArray: string[] = currentLine.text.replace(/\t/g, " ").trim().split(" ");
+				currentLineArray = currentLineArray.filter((e) => {
+					return (e.trim().length > 0);
+				});
+				if (currentLineArray.length === 2) {
+					elementName = currentLineArray[1];
+				}
 				break;
 			}
 		}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,8 +1,8 @@
 import fs = require('fs');
 import path = require('path');
 import { FileStream, CommonTokenStream } from 'antlr4/index';
-const { SHRDataElementParser } = require('./parsers/SHRDataElementParser');
-const { SHRDataElementLexer } = require('./parsers/SHRDataElementLexer');
+const { SHRDataElementParser } = require('./parsers/SHRDataElementParser.js');
+const { SHRDataElementLexer } = require('./parsers/SHRDataElementLexer.js');
 
 export function importFromFilePath(filePath: string) {
   const filesByType = processPath(filePath);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3,10 +3,6 @@ import path = require('path');
 import { FileStream, CommonTokenStream } from 'antlr4/index';
 const { SHRDataElementParser } = require('./parsers/SHRDataElementParser.js');
 const { SHRDataElementLexer } = require('./parsers/SHRDataElementLexer.js');
-const { SHRValueSetLexer } = require('./parsers/SHRValueSetLexer.js');
-const { SHRValueSetParser } = require ('./parsers/SHRValueSetParser.js');
-const { SHRMapLexer } = require('./parsers/SHRMapLexer.js');
-const { SHRMapParser } = require ('./parsers/SHRMapParser.js');
 
 export function importFromFilePath(filePath: string) {
   const filesByType = processPath(filePath);
@@ -18,28 +14,6 @@ export function importFromFilePath(filePath: string) {
     lexer.removeErrorListeners(); // Only log errors during the import
     const tokens = new CommonTokenStream(lexer);
     const parser = new SHRDataElementParser(tokens);
-    parser.removeErrorListeners(); // Only log errors during the import
-    parser.buildParseTrees = true;
-    tree[file] = parser.doc();
-  }
-
-  for (const file of filesByType.valueSet) {
-    const chars = new FileStream(file);
-    const lexer = new SHRValueSetLexer(chars);
-    lexer.removeErrorListeners(); // Only log errors during the import
-    const tokens = new CommonTokenStream(lexer);
-    const parser = new SHRValueSetParser(tokens);
-    parser.removeErrorListeners(); // Only log errors during the import
-    parser.buildParseTrees = true;
-    tree[file] = parser.doc();
-  }
-
-  for (const file of filesByType.map) {
-    const chars = new FileStream(file);
-    const lexer = new SHRMapLexer(chars);
-    lexer.removeErrorListeners(); // Only log errors during the import
-    const tokens = new CommonTokenStream(lexer);
-    const parser = new SHRMapParser(tokens);
     parser.removeErrorListeners(); // Only log errors during the import
     parser.buildParseTrees = true;
     tree[file] = parser.doc();

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3,6 +3,10 @@ import path = require('path');
 import { FileStream, CommonTokenStream } from 'antlr4/index';
 const { SHRDataElementParser } = require('./parsers/SHRDataElementParser.js');
 const { SHRDataElementLexer } = require('./parsers/SHRDataElementLexer.js');
+const { SHRValueSetLexer } = require('./parsers/SHRValueSetLexer.js');
+const { SHRValueSetParser } = require ('./parsers/SHRValueSetParser.js');
+const { SHRMapLexer } = require('./parsers/SHRMapLexer.js');
+const { SHRMapParser } = require ('./parsers/SHRMapParser.js');
 
 export function importFromFilePath(filePath: string) {
   const filesByType = processPath(filePath);
@@ -18,6 +22,29 @@ export function importFromFilePath(filePath: string) {
     parser.buildParseTrees = true;
     tree[file] = parser.doc();
   }
+
+  for (const file of filesByType.valueSet) {
+    const chars = new FileStream(file);
+    const lexer = new SHRValueSetLexer(chars);
+    lexer.removeErrorListeners(); // Only log errors during the import
+    const tokens = new CommonTokenStream(lexer);
+    const parser = new SHRValueSetParser(tokens);
+    parser.removeErrorListeners(); // Only log errors during the import
+    parser.buildParseTrees = true;
+    tree[file] = parser.doc();
+  }
+
+  for (const file of filesByType.map) {
+    const chars = new FileStream(file);
+    const lexer = new SHRMapLexer(chars);
+    lexer.removeErrorListeners(); // Only log errors during the import
+    const tokens = new CommonTokenStream(lexer);
+    const parser = new SHRMapParser(tokens);
+    parser.removeErrorListeners(); // Only log errors during the import
+    parser.buildParseTrees = true;
+    tree[file] = parser.doc();
+  }
+
   return tree;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
+		"allowJs": true,
 		"target": "es5",
 		"outDir": "out",
 		"lib": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
 		"rootDir": "src"
 	},
 	"exclude": [
-		"node_modules"
+		"node_modules",
+		"out"
 	]
 }


### PR DESCRIPTION
This PR adds a "Go to Definition" command that can be used. To execute the command, open the command palette with:

Mac: <kbd>shift</kbd> + <kbd>command</kbd> + <kbd>P</kbd>
Windows: <kbd>shift</kbd> + <kbd>ctrl</kbd> + <kbd>P</kbd>

Then, scroll or type to find and select the "Go to Definition" command. **Note**: Commands can be bound to keys in VS Code personal preferences, so this should likely be done for anyone who plans to use this command regularly.

If the name of an element is highlighted in a file and this command is executed, the VS code editor will look through the files in the workspace and open the definition of this element in the relevant file. If there is no selected text, or there was no definition found, or there are no workspace files or active editor, an appropriate error message should be displayed.

@cmoesel, since this is the first time you will have looked at this code, we should probably sit down and go over this one together. There is some effort required to get a VS Code extension debugger working, as well, so I can walk you through that too.