### PR TITLE
Definition Integration, and Code Cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description": "VSCode CIMPL Language Support",
 	"author": "The MITRE Corporation",
 	"license": "Apache-2.0",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"publisher": "Standard Health Record",
 	"repository": {
 		"type": "git",
@@ -46,8 +46,8 @@
 		],
 		"commands": [
 			{
-				"command": "extension.showInheritedAttributes",
-				"title": "Show Inherited Attributes"
+				"command": "extension.getInheritedAttributes",
+				"title": "Get Inherited Attributes"
 			}
 		]
 	},

--- a/package.json
+++ b/package.json
@@ -46,12 +46,8 @@
 		],
 		"commands": [
 			{
-				"command": "extension.goToDefinition",
-				"title": "Go to Definition"
-			},
-			{
-				"command": "extension.getInheritedAttributes",
-				"title": "Get Inherited Attributes"
+				"command": "extension.showInheritedAttributes",
+				"title": "Show Inherited Attributes"
 			}
 		]
 	},


### PR DESCRIPTION
This PR removes the Go to Definition command, and integrates this functionality into VS Code through the default Go to Definition and Peek Definition functionality.

This also cleans up the code significantly, by utilizing more of the ANTLR grammar parser functionality.