### PR TITLE
Go to Definition Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description": "VSCode CIMPL Language Support",
 	"author": "The MITRE Corporation",
 	"license": "Apache-2.0",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"publisher": "Standard Health Record",
 	"repository": {
 		"type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,7 +108,7 @@ const getDefinitionLocation = (document, position) => {
 
 			if (simpleName && (simpleName.start.text === word)) {
 				lineNumber = simpleName.start.line;
-				return new Location(Uri.file(fileName), document.lineAt(lineNumber - 1).range);
+				return new Location(Uri.file(fileName), new Position(lineNumber - 1, 0));
 			}
 		};
 	}


### PR DESCRIPTION
Fixes #15.

It turns out that the issue ended up not being related to the `or` at all. The issue was related to the length of the file.

The go to definition operation was depending on the line number of the **current** file rather than the destination file, meaning that when the destination file had a definition at a line number higher than the length of the current file, it would break.

This has been resolved.